### PR TITLE
Add settings and menu management pages

### DIFF
--- a/frontend-admin/src/App.vue
+++ b/frontend-admin/src/App.vue
@@ -6,22 +6,22 @@
       <div class="logo">Layered CMS</div>
       <!-- 导航菜单 -->
       <el-menu
+        router
+        :default-active="activeMenu"
         active-text-color="#ffd04b"
         background-color="#545c64"
         class="el-menu-vertical-demo"
-        default-active="2"
         text-color="#fff"
       >
-        <!-- 之后这里会用 v-for 根据路由动态生成 -->
-        <el-menu-item index="1">
+        <el-menu-item index="/settings">
           <el-icon><setting /></el-icon>
           <span>全局设置</span>
         </el-menu-item>
-        <el-menu-item index="2">
+        <el-menu-item index="/layers">
           <el-icon><Grid /></el-icon>
           <span>层级管理</span>
         </el-menu-item>
-        <el-menu-item index="3">
+        <el-menu-item index="/menu">
           <el-icon><List /></el-icon>
           <span>菜单管理</span>
         </el-menu-item>
@@ -49,20 +49,18 @@
 
       <!-- 主内容区 -->
       <el-main class="app-main">
-        <!-- 
-          这里是将来路由切换时，不同页面组件显示的地方。
-          现在我们先放一个占位符。
-        -->
-        <h2>欢迎使用 Layered Layout CMS!</h2>
-        <p>请从左侧菜单选择一项开始管理。</p>
+        <router-view />
       </el-main>
     </el-container>
   </el-container>
 </template>
 
 <script setup>
-// Script setup is used for Vue 3 Composition API.
-// We can define component logic here in the future.
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+
+const route = useRoute();
+const activeMenu = computed(() => route.path);
 </script>
 
 <style>

--- a/frontend-admin/src/views/GlobalSettings.vue
+++ b/frontend-admin/src/views/GlobalSettings.vue
@@ -6,13 +6,79 @@
           <span>全局设置</span>
         </div>
       </template>
-      <p>这里将放置用于管理网站 Logo、字体和颜色的表单。</p>
+      <el-form :model="form" :rules="rules" ref="formRef" label-width="120px" v-loading="loading">
+        <el-form-item label="Logo URL" prop="logoUrl">
+          <el-input v-model="form.logoUrl" placeholder="https://example.com/logo.png" />
+        </el-form-item>
+        <el-form-item label="字体" prop="fontFamily">
+          <el-input v-model="form.fontFamily" placeholder="例如: Arial, sans-serif" />
+        </el-form-item>
+        <el-form-item label="主色调" prop="primaryColor">
+          <el-color-picker v-model="form.primaryColor" />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" @click="handleSubmit">保存</el-button>
+        </el-form-item>
+      </el-form>
+      <el-alert v-if="error" type="error" :title="error" show-icon class="error-alert" />
     </el-card>
   </div>
 </template>
 
 <script setup>
-// 未来在这里编写获取和更新设置的逻辑
+import { ref, onMounted } from 'vue';
+import { ElMessage } from 'element-plus';
+import { getSettings, updateSettings } from '../services/settings.service.js';
+
+const formRef = ref(null);
+const form = ref({ logoUrl: '', fontFamily: '', primaryColor: '' });
+const loading = ref(false);
+const error = ref('');
+
+const rules = {
+  logoUrl: [{ required: true, message: '请输入 Logo URL', trigger: 'blur' }],
+  fontFamily: [{ required: true, message: '请输入字体', trigger: 'blur' }],
+  primaryColor: [{ required: true, message: '请选择颜色', trigger: 'change' }],
+};
+
+const fetchSettings = async () => {
+  loading.value = true;
+  error.value = '';
+  try {
+    const res = await getSettings();
+    if (res.data && res.data.success) {
+      form.value = res.data.data;
+    } else {
+      throw new Error(res.data.message || '获取设置失败');
+    }
+  } catch (err) {
+    error.value = err.message || '获取设置失败';
+  } finally {
+    loading.value = false;
+  }
+};
+
+const handleSubmit = async () => {
+  if (!formRef.value) return;
+  await formRef.value.validate(async (valid) => {
+    if (!valid) return;
+    try {
+      const res = await updateSettings(form.value);
+      if (res.data && res.data.success) {
+        ElMessage.success('保存成功！');
+        fetchSettings();
+      } else {
+        throw new Error(res.data.message || '保存失败');
+      }
+    } catch (err) {
+      ElMessage.error(err.message || '保存失败');
+    }
+  });
+};
+
+onMounted(() => {
+  fetchSettings();
+});
 </script>
 
 <style scoped>
@@ -23,5 +89,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+.error-alert {
+  margin-top: 20px;
 }
 </style>

--- a/frontend-admin/src/views/MenuManager.vue
+++ b/frontend-admin/src/views/MenuManager.vue
@@ -6,13 +6,145 @@
           <span>菜单管理</span>
         </div>
       </template>
-      <p>这里将放置用于管理弹出菜单项的表格。</p>
+      <div class="toolbar">
+        <el-button type="primary" :icon="Plus" @click="handleCreate">新建菜单项</el-button>
+      </div>
+      <el-alert v-if="error" :title="'数据加载失败: ' + error" type="error" show-icon class="error-alert" />
+      <el-table :data="tableData" v-loading="loading" style="width:100%">
+        <el-table-column prop="title" label="标题" width="180" />
+        <el-table-column prop="link" label="链接" />
+        <el-table-column prop="order" label="排序" width="80" sortable />
+        <el-table-column label="状态" width="100">
+          <template #default="scope">
+            <el-tag :type="scope.row.isEnabled ? 'success' : 'info'">
+              {{ scope.row.isEnabled ? '已启用' : '已禁用' }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column label="最后更新" width="200">
+          <template #default="scope">
+            {{ formatDateTime(scope.row.updatedAt) }}
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="200" fixed="right">
+          <template #default="scope">
+            <el-button size="small" type="primary" @click="handleEdit(scope.row)">编辑</el-button>
+            <el-button size="small" type="danger" @click="handleDelete(scope.row)">删除</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <menu-item-form
+        :visible="isFormVisible"
+        :initial-data="editingItem"
+        @close="handleFormClose"
+        @submit="handleFormSubmit"
+      />
     </el-card>
   </div>
 </template>
 
 <script setup>
-// 未来在这里编写获取和管理菜单项的逻辑
+import { ref, onMounted } from 'vue';
+import { Plus } from '@element-plus/icons-vue';
+import { ElMessage, ElMessageBox } from 'element-plus';
+import { getMenuItems, createMenuItem, updateMenuItem, deleteMenuItem } from '../services/menu.service.js';
+import MenuItemForm from '../components/MenuItemForm.vue';
+
+const loading = ref(true);
+const tableData = ref([]);
+const error = ref('');
+
+const isFormVisible = ref(false);
+const editingItem = ref(null);
+
+const fetchItems = async () => {
+  loading.value = true;
+  error.value = '';
+  try {
+    const res = await getMenuItems();
+    if (res.data && res.data.success) {
+      tableData.value = res.data.data;
+    } else {
+      throw new Error(res.data.message || '加载失败');
+    }
+  } catch (err) {
+    error.value = err.message || '加载失败';
+  } finally {
+    loading.value = false;
+  }
+};
+
+const handleCreate = () => {
+  editingItem.value = { order: 0, isEnabled: true };
+  isFormVisible.value = true;
+};
+
+const handleEdit = (row) => {
+  editingItem.value = { ...row };
+  isFormVisible.value = true;
+};
+
+const handleFormClose = () => {
+  isFormVisible.value = false;
+  editingItem.value = null;
+};
+
+const handleFormSubmit = async (data) => {
+  try {
+    let res;
+    if (data._id) {
+      res = await updateMenuItem(data._id, data);
+    } else {
+      res = await createMenuItem(data);
+    }
+    if (res.data && res.data.success) {
+      ElMessage.success('保存成功！');
+      handleFormClose();
+      fetchItems();
+    } else {
+      throw new Error(res.data.message || '保存失败');
+    }
+  } catch (err) {
+    ElMessage.error(err.message || '保存失败');
+  }
+};
+
+const handleDelete = (row) => {
+  ElMessageBox.confirm(
+    `确定删除菜单项 "${row.title}" 吗？`,
+    '警告',
+    { confirmButtonText: '删除', cancelButtonText: '取消', type: 'warning' }
+  ).then(async () => {
+    try {
+      const res = await deleteMenuItem(row._id);
+      if (res.data && res.data.success) {
+        ElMessage.success('删除成功！');
+        fetchItems();
+      } else {
+        throw new Error(res.data.message || '删除失败');
+      }
+    } catch (err) {
+      ElMessage.error(err.message || '删除失败');
+    }
+  }).catch(() => {
+    ElMessage.info('已取消删除');
+  });
+};
+
+const formatDateTime = (iso) => {
+  if (!iso) return 'N/A';
+  const date = new Date(iso);
+  return date.toLocaleString('zh-CN', {
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+    hour12: false
+  });
+};
+
+onMounted(() => {
+  fetchItems();
+});
 </script>
 
 <style scoped>
@@ -23,5 +155,11 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+.toolbar {
+  margin-bottom: 15px;
+}
+.error-alert {
+  margin-bottom: 20px;
 }
 </style>


### PR DESCRIPTION
## Summary
- add editable form to GlobalSettings
- build table and form integration for MenuManager
- enable router navigation in admin layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e7583b94832db3794597b2674547