### PR TITLE
Implement form management

### DIFF
--- a/backend/src/api/forms.routes.js
+++ b/backend/src/api/forms.routes.js
@@ -1,0 +1,25 @@
+import express from 'express';
+import {
+  createForm,
+  getAllForms,
+  getFormById,
+  updateForm,
+  deleteForm,
+  submitToForm,
+} from '../controllers/forms.controller.js';
+
+const router = express.Router();
+
+router.route('/')
+  .get(getAllForms)
+  .post(createForm);
+
+router.route('/:id')
+  .get(getFormById)
+  .put(updateForm)
+  .delete(deleteForm);
+
+router.route('/:id/submit')
+  .post(submitToForm);
+
+export default router;

--- a/backend/src/controllers/forms.controller.js
+++ b/backend/src/controllers/forms.controller.js
@@ -1,0 +1,86 @@
+import Form from '../models/Form.model.js';
+import Submission from '../models/Submission.model.js';
+
+// @desc    创建新的表单
+// @route   POST /api/forms
+export const createForm = async (req, res) => {
+  try {
+    const form = new Form(req.body);
+    const saved = await form.save();
+    res.status(201).json({ success: true, data: saved });
+  } catch (error) {
+    res.status(500).json({ success: false, message: 'Error creating form.', error: error.message });
+  }
+};
+
+// @desc    获取所有表单
+// @route   GET /api/forms
+export const getAllForms = async (req, res) => {
+  try {
+    const forms = await Form.find();
+    res.status(200).json({ success: true, count: forms.length, data: forms });
+  } catch (error) {
+    res.status(500).json({ success: false, message: 'Error fetching forms.', error: error.message });
+  }
+};
+
+// @desc    获取单个表单
+// @route   GET /api/forms/:id
+export const getFormById = async (req, res) => {
+  try {
+    const form = await Form.findById(req.params.id);
+    if (!form) {
+      return res.status(404).json({ success: false, message: 'Form not found.' });
+    }
+    res.status(200).json({ success: true, data: form });
+  } catch (error) {
+    res.status(500).json({ success: false, message: 'Error fetching form.', error: error.message });
+  }
+};
+
+// @desc    更新表单
+// @route   PUT /api/forms/:id
+export const updateForm = async (req, res) => {
+  try {
+    const updated = await Form.findByIdAndUpdate(req.params.id, req.body, {
+      new: true,
+      runValidators: true,
+    });
+    if (!updated) {
+      return res.status(404).json({ success: false, message: 'Form not found.' });
+    }
+    res.status(200).json({ success: true, data: updated });
+  } catch (error) {
+    res.status(500).json({ success: false, message: 'Error updating form.', error: error.message });
+  }
+};
+
+// @desc    删除表单
+// @route   DELETE /api/forms/:id
+export const deleteForm = async (req, res) => {
+  try {
+    const deleted = await Form.findByIdAndDelete(req.params.id);
+    if (!deleted) {
+      return res.status(404).json({ success: false, message: 'Form not found.' });
+    }
+    res.status(200).json({ success: true, message: 'Form deleted successfully.' });
+  } catch (error) {
+    res.status(500).json({ success: false, message: 'Error deleting form.', error: error.message });
+  }
+};
+
+// @desc    提交表单
+// @route   POST /api/forms/:id/submit
+export const submitToForm = async (req, res) => {
+  try {
+    const form = await Form.findById(req.params.id);
+    if (!form || !form.isEnabled) {
+      return res.status(404).json({ success: false, message: 'Form not found.' });
+    }
+    const submission = new Submission({ form: form._id, data: req.body });
+    const saved = await submission.save();
+    res.status(201).json({ success: true, data: saved });
+  } catch (error) {
+    res.status(500).json({ success: false, message: 'Error submitting form.', error: error.message });
+  }
+};

--- a/backend/src/models/Form.model.js
+++ b/backend/src/models/Form.model.js
@@ -1,0 +1,31 @@
+import mongoose from 'mongoose';
+const { Schema } = mongoose;
+
+// 定义单个表单字段的结构
+const FieldSchema = new Schema({
+  label: { type: String, required: true, trim: true },
+  name: { type: String, required: true, trim: true },
+  type: { type: String, required: true, trim: true },
+  required: { type: Boolean, default: false },
+  options: [String],
+}, { _id: false });
+
+// 主表单 Schema
+const FormSchema = new Schema({
+  name: {
+    type: String,
+    required: [true, 'Form name is required.'],
+    trim: true,
+  },
+  fields: [FieldSchema],
+  isEnabled: {
+    type: Boolean,
+    default: true,
+  },
+}, {
+  timestamps: true,
+});
+
+const Form = mongoose.model('Form', FormSchema);
+
+export default Form;

--- a/backend/src/models/Submission.model.js
+++ b/backend/src/models/Submission.model.js
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose';
+const { Schema } = mongoose;
+
+const SubmissionSchema = new Schema({
+  form: { type: Schema.Types.ObjectId, ref: 'Form', required: true },
+  data: { type: Object, required: true },
+}, {
+  timestamps: true,
+});
+
+const Submission = mongoose.model('Submission', SubmissionSchema);
+
+export default Submission;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -10,6 +10,7 @@ import connectDB from './config/db.js';
 // 导入路由文件
 import layersRoutes from './api/layers.routes.js';
 import settingsRoutes from './api/settings.routes.js'; // 新增：导入 settings 路由
+import formsRoutes from './api/forms.routes.js';
 // (未来可以导入更多路由)
 // import menuRoutes from './api/menu.routes.js';
 
@@ -35,6 +36,8 @@ app.use(express.json());
 app.use('/api/layers', layersRoutes);
 // 新增：当请求路径以 /api/settings 开头时，使用 settingsRoutes 处理
 app.use('/api/settings', settingsRoutes);
+// 表单相关路由
+app.use('/api/forms', formsRoutes);
 // (未来可以挂载更多路由)
 // app.use('/api/menu', menuRoutes);
 

--- a/frontend-admin/src/components/FormForm.vue
+++ b/frontend-admin/src/components/FormForm.vue
@@ -1,0 +1,118 @@
+<template>
+  <el-dialog
+    :model-value="visible"
+    :title="isEditMode ? '编辑表单' : '新建表单'"
+    width="60%"
+    @close="handleClose"
+  >
+    <el-form :model="form" :rules="rules" ref="formRef" label-width="100px">
+      <el-form-item label="表单名称" prop="name">
+        <el-input v-model="form.name" placeholder="例如：联系表单" />
+      </el-form-item>
+      <el-form-item label="是否启用" prop="isEnabled">
+        <el-switch v-model="form.isEnabled" />
+      </el-form-item>
+      <el-form-item label="字段列表">
+        <el-table :data="form.fields" style="width:100%">
+          <el-table-column label="标签">
+            <template #default="scope">
+              <el-input v-model="scope.row.label" />
+            </template>
+          </el-table-column>
+          <el-table-column label="字段名">
+            <template #default="scope">
+              <el-input v-model="scope.row.name" />
+            </template>
+          </el-table-column>
+          <el-table-column label="类型">
+            <template #default="scope">
+              <el-select v-model="scope.row.type" style="width:120px">
+                <el-option label="文本" value="text" />
+                <el-option label="邮箱" value="email" />
+                <el-option label="多行文本" value="textarea" />
+                <el-option label="数字" value="number" />
+              </el-select>
+            </template>
+          </el-table-column>
+          <el-table-column label="必填" width="80">
+            <template #default="scope">
+              <el-switch v-model="scope.row.required" />
+            </template>
+          </el-table-column>
+          <el-table-column label="操作" width="80">
+            <template #default="scope">
+              <el-button type="danger" size="small" @click="removeField(scope.$index)">删除</el-button>
+            </template>
+          </el-table-column>
+        </el-table>
+        <el-button class="add-field" type="primary" plain icon="Plus" @click="addField">新增字段</el-button>
+      </el-form-item>
+    </el-form>
+    <template #footer>
+      <span class="dialog-footer">
+        <el-button @click="handleClose">取 消</el-button>
+        <el-button type="primary" @click="handleSubmit">确 定</el-button>
+      </span>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup>
+import { ref, watch, computed } from 'vue';
+import { Plus } from '@element-plus/icons-vue';
+
+const props = defineProps({
+  visible: Boolean,
+  initialData: Object,
+});
+
+const emit = defineEmits(['close', 'submit']);
+
+const formRef = ref(null);
+const form = ref({ fields: [] });
+
+const isEditMode = computed(() => !!(props.initialData && props.initialData._id));
+
+const rules = {
+  name: [{ required: true, message: '请输入表单名称', trigger: 'blur' }],
+};
+
+watch(
+  () => props.initialData,
+  (newData) => {
+    form.value = { fields: [], isEnabled: true, ...newData };
+    if (!form.value.fields) form.value.fields = [];
+  },
+  { immediate: true, deep: true }
+);
+
+const addField = () => {
+  form.value.fields.push({ label: '', name: '', type: 'text', required: false });
+};
+
+const removeField = (index) => {
+  form.value.fields.splice(index, 1);
+};
+
+const handleClose = () => {
+  emit('close');
+};
+
+const handleSubmit = async () => {
+  if (!formRef.value) return;
+  await formRef.value.validate((valid) => {
+    if (valid) {
+      emit('submit', form.value);
+    }
+  });
+};
+</script>
+
+<style scoped>
+.dialog-footer {
+  text-align: right;
+}
+.add-field {
+  margin-top: 10px;
+}
+</style>

--- a/frontend-admin/src/router/index.js
+++ b/frontend-admin/src/router/index.js
@@ -7,6 +7,7 @@ import { createRouter, createWebHistory } from 'vue-router';
 // 导入页面组件
 // LayerManager.vue 已经创建
 import LayerManager from '../views/LayerManager.vue';
+import FormManager from '../views/FormManager.vue';
 
 // 我们需要为其他菜单项创建对应的页面组件
 // 下面我们先导入，然后立即创建这两个占位文件
@@ -24,6 +25,12 @@ const routes = [
     name: 'LayerManager',
     component: LayerManager,
     meta: { title: '层级管理', icon: 'Grid' } // meta 用于侧边栏生成
+  },
+  {
+    path: '/forms',
+    name: 'FormManager',
+    component: FormManager,
+    meta: { title: '表单管理', icon: 'Tickets' }
   },
   {
     path: '/settings',

--- a/frontend-admin/src/services/forms.service.js
+++ b/frontend-admin/src/services/forms.service.js
@@ -1,0 +1,21 @@
+import apiClient from './apiClient';
+
+export const getForms = () => {
+  return apiClient.get('/forms');
+};
+
+export const createForm = (data) => {
+  return apiClient.post('/forms', data);
+};
+
+export const updateForm = (id, data) => {
+  return apiClient.put(`/forms/${id}`, data);
+};
+
+export const deleteForm = (id) => {
+  return apiClient.delete(`/forms/${id}`);
+};
+
+export const submitForm = (id, data) => {
+  return apiClient.post(`/forms/${id}/submit`, data);
+};

--- a/frontend-admin/src/views/FormManager.vue
+++ b/frontend-admin/src/views/FormManager.vue
@@ -1,0 +1,175 @@
+<template>
+  <div class="page-container">
+    <el-card>
+      <template #header>
+        <div class="card-header">
+          <span>表单管理</span>
+          <el-button type="primary" :icon="Plus" @click="handleCreate">新建表单</el-button>
+        </div>
+      </template>
+
+      <el-alert
+        v-if="error"
+        :title="'数据加载失败: ' + error"
+        type="error"
+        show-icon
+        :closable="false"
+        class="error-alert"
+      />
+
+      <el-table :data="tableData" style="width: 100%" v-loading="loading">
+        <el-table-column prop="name" label="表单名称" />
+        <el-table-column label="状态" width="100">
+          <template #default="scope">
+            <el-tag :type="scope.row.isEnabled ? 'success' : 'info'">
+              {{ scope.row.isEnabled ? '已启用' : '已禁用' }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column label="最后更新" width="200">
+          <template #default="scope">
+            {{ formatDateTime(scope.row.updatedAt) }}
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="200" fixed="right">
+          <template #default="scope">
+            <el-button size="small" type="primary" @click="handleEdit(scope.row)">编辑</el-button>
+            <el-button size="small" type="danger" @click="handleDelete(scope.row)">删除</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+    </el-card>
+
+    <form-form
+      :visible="isFormVisible"
+      :initial-data="editingForm"
+      @close="handleFormClose"
+      @submit="handleFormSubmit"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { Plus } from '@element-plus/icons-vue';
+import { ElMessage, ElMessageBox } from 'element-plus';
+import { getForms, deleteForm, createForm, updateForm } from '../services/forms.service.js';
+import FormForm from '../components/FormForm.vue';
+
+const loading = ref(true);
+const tableData = ref([]);
+const error = ref(null);
+const isFormVisible = ref(false);
+const editingForm = ref(null);
+
+const fetchForms = async () => {
+  loading.value = true;
+  error.value = null;
+  try {
+    const res = await getForms();
+    if (res.data && res.data.success) {
+      tableData.value = res.data.data;
+    } else {
+      throw new Error(res.data.message || 'Failed to fetch');
+    }
+  } catch (err) {
+    console.error('Error fetching forms:', err);
+    error.value = err.message || 'Unknown error';
+  } finally {
+    loading.value = false;
+  }
+};
+
+const handleCreate = () => {
+  editingForm.value = { fields: [], isEnabled: true };
+  isFormVisible.value = true;
+};
+
+const handleEdit = (row) => {
+  editingForm.value = { ...row };
+  isFormVisible.value = true;
+};
+
+const handleFormClose = () => {
+  isFormVisible.value = false;
+  editingForm.value = null;
+};
+
+const handleFormSubmit = async (data) => {
+  try {
+    let response;
+    if (data._id) {
+      response = await updateForm(data._id, data);
+    } else {
+      response = await createForm(data);
+    }
+    if (response.data && response.data.success) {
+      ElMessage.success(data._id ? '更新成功！' : '创建成功！');
+      handleFormClose();
+      fetchForms();
+    } else {
+      throw new Error(response.data.message || '操作失败');
+    }
+  } catch (err) {
+    console.error('Error submitting form:', err);
+    ElMessage.error(err.message || '提交时发生错误');
+  }
+};
+
+const handleDelete = (row) => {
+  ElMessageBox.confirm(
+    `您确定要删除表单 "${row.name}" 吗？此操作无法撤销。`,
+    '警告',
+    { confirmButtonText: '确定删除', cancelButtonText: '取消', type: 'warning' }
+  )
+    .then(async () => {
+      try {
+        const response = await deleteForm(row._id);
+        if (response.data && response.data.success) {
+          ElMessage.success('删除成功！');
+          fetchForms();
+        } else {
+          throw new Error(response.data.message || '删除失败');
+        }
+      } catch (err) {
+        console.error('Error deleting form:', err);
+        ElMessage.error(err.message || '删除时发生错误');
+      }
+    })
+    .catch(() => {
+      ElMessage.info('已取消删除');
+    });
+};
+
+const formatDateTime = (isoString) => {
+  if (!isoString) return 'N/A';
+  const date = new Date(isoString);
+  return date.toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+};
+
+onMounted(() => {
+  fetchForms();
+});
+</script>
+
+<style scoped>
+.page-container {
+  padding: 20px;
+}
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.error-alert {
+  margin-bottom: 20px;
+}
+</style>


### PR DESCRIPTION
## Summary
- define models for forms and submissions
- add controller methods for forms API and submission handler
- create routes for forms endpoints and mount in server
- add admin service utilities and form editor components
- build FormManager page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6880e754d260832d94ea2301022d25cd