### PR TITLE
Add basic JWT authentication

### DIFF
--- a/backend/src/api/auth.routes.js
+++ b/backend/src/api/auth.routes.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import { registerUser, loginUser } from '../controllers/auth.controller.js';
+
+const router = express.Router();
+
+router.post('/register', registerUser);
+router.post('/login', loginUser);
+
+export default router;

--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -1,0 +1,61 @@
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import User from '../models/User.model.js';
+
+// Generate JWT token
+const generateToken = (userId) => {
+  return jwt.sign({ id: userId }, process.env.JWT_SECRET, {
+    expiresIn: '7d',
+  });
+};
+
+// @desc    Register new user
+// @route   POST /api/auth/register
+// @access  Public
+export const registerUser = async (req, res) => {
+  try {
+    const { email, password, role } = req.body;
+
+    if (!email || !password) {
+      return res.status(400).json({ success: false, message: 'Email and password are required.' });
+    }
+
+    const existing = await User.findOne({ email });
+    if (existing) {
+      return res.status(400).json({ success: false, message: 'User already exists.' });
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+    const user = await User.create({ email, passwordHash, role });
+
+    const token = generateToken(user._id);
+
+    res.status(201).json({ success: true, token });
+  } catch (err) {
+    res.status(500).json({ success: false, message: 'Registration failed', error: err.message });
+  }
+};
+
+// @desc    Login user
+// @route   POST /api/auth/login
+// @access  Public
+export const loginUser = async (req, res) => {
+  try {
+    const { email, password } = req.body;
+
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(401).json({ success: false, message: 'Invalid credentials' });
+    }
+
+    const isMatch = await bcrypt.compare(password, user.passwordHash);
+    if (!isMatch) {
+      return res.status(401).json({ success: false, message: 'Invalid credentials' });
+    }
+
+    const token = generateToken(user._id);
+    res.status(200).json({ success: true, token });
+  } catch (err) {
+    res.status(500).json({ success: false, message: 'Login failed', error: err.message });
+  }
+};

--- a/backend/src/middleware/auth.middleware.js
+++ b/backend/src/middleware/auth.middleware.js
@@ -1,0 +1,26 @@
+import jwt from 'jsonwebtoken';
+import User from '../models/User.model.js';
+
+export const protect = async (req, res, next) => {
+  let token;
+
+  if (req.headers.authorization && req.headers.authorization.startsWith('Bearer')) {
+    token = req.headers.authorization.split(' ')[1];
+  }
+
+  if (!token) {
+    return res.status(401).json({ success: false, message: 'Not authorized, no token' });
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const user = await User.findById(decoded.id).select('-passwordHash');
+    if (!user) {
+      return res.status(401).json({ success: false, message: 'User not found' });
+    }
+    req.user = user;
+    next();
+  } catch (err) {
+    res.status(401).json({ success: false, message: 'Token failed', error: err.message });
+  }
+};

--- a/backend/src/models/User.model.js
+++ b/backend/src/models/User.model.js
@@ -1,0 +1,30 @@
+import mongoose from 'mongoose';
+const { Schema } = mongoose;
+
+const UserSchema = new Schema(
+  {
+    email: {
+      type: String,
+      required: [true, 'Email is required'],
+      unique: true,
+      trim: true,
+      lowercase: true,
+    },
+    passwordHash: {
+      type: String,
+      required: [true, 'Password hash is required'],
+    },
+    role: {
+      type: String,
+      enum: ['user', 'admin'],
+      default: 'user',
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+const User = mongoose.model('User', UserSchema);
+
+export default User;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -13,6 +13,9 @@ import settingsRoutes from './api/settings.routes.js'; // 新增：导入 settin
 // (未来可以导入更多路由)
 import menuRoutes from './api/menu.routes.js';
 import publicRoutes from './api/public.routes.js';
+import authRoutes from './api/auth.routes.js';
+
+import { protect } from './middleware/auth.middleware.js';
 
 // --- 初始化 ---
 // 加载 .env 文件中的环境变量
@@ -32,12 +35,14 @@ app.use(cors());
 app.use(express.json());
 
 // --- API 路由 ---
+app.use('/api/auth', authRoutes);
+
 // 当请求路径以 /api/layers 开头时，使用 layersRoutes 处理
-app.use('/api/layers', layersRoutes);
+app.use('/api/layers', protect, layersRoutes);
 // 新增：当请求路径以 /api/settings 开头时，使用 settingsRoutes 处理
-app.use('/api/settings', settingsRoutes);
+app.use('/api/settings', protect, settingsRoutes);
 // (未来可以挂载更多路由)
-app.use('/api/menu', menuRoutes);
+app.use('/api/menu', protect, menuRoutes);
 app.use('/api/public', publicRoutes);
 
 

--- a/frontend-admin/src/main.js
+++ b/frontend-admin/src/main.js
@@ -16,8 +16,8 @@ import * as ElementPlusIconsVue from '@element-plus/icons-vue';
 // 引入路由 (我们稍后会创建 router/index.js)
 import router from './router'; // 取消注释，引入路由
 
-// 引入状态管理 Pinia (我们稍后会创建 store/index.js)
-// import { createPinia } from 'pinia';
+// 引入状态管理 Pinia
+import { createPinia } from 'pinia';
 
 // 创建 Vue 应用实例
 const app = createApp(App);
@@ -30,7 +30,7 @@ for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
 // 使用插件
 app.use(ElementPlus);
 app.use(router); // 取消注释，启用路由
-// app.use(createPinia());
+app.use(createPinia());
 
 // 将应用挂载到 public/index.html 文件中 id 为 'app' 的元素上
 app.mount('#app');

--- a/frontend-admin/src/router/index.js
+++ b/frontend-admin/src/router/index.js
@@ -12,6 +12,7 @@ import LayerManager from '../views/LayerManager.vue';
 // 下面我们先导入，然后立即创建这两个占位文件
 import GlobalSettings from '../views/GlobalSettings.vue';
 import MenuManager from '../views/MenuManager.vue';
+import Login from '../views/Login.vue';
 
 // 定义路由规则
 const routes = [
@@ -37,12 +38,12 @@ const routes = [
     component: MenuManager,
     meta: { title: '菜单管理', icon: 'List' }
   },
-  // 未来可以添加登录页等其他路由
-  // {
-  //   path: '/login',
-  //   name: 'Login',
-  //   component: () => import('../views/Login.vue')
-  // }
+  {
+    path: '/login',
+    name: 'Login',
+    component: Login,
+    meta: { title: '登录' }
+  }
 ];
 
 // 创建路由实例

--- a/frontend-admin/src/services/apiClient.js
+++ b/frontend-admin/src/services/apiClient.js
@@ -13,26 +13,27 @@ const apiClient = axios.create({
   },
 });
 
-// 你可以在这里添加请求拦截器，例如，在每个请求中附加认证 token
-// apiClient.interceptors.request.use(config => {
-//   const token = localStorage.getItem('token');
-//   if (token) {
-//     config.headers.Authorization = `Bearer ${token}`;
-//   }
-//   return config;
-// }, error => {
-//   return Promise.reject(error);
-// });
+// 在每个请求中附加认证 token
+apiClient.interceptors.request.use(
+  config => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  error => Promise.reject(error)
+);
 
-// 你也可以添加响应拦截器，用于统一处理错误
-// apiClient.interceptors.response.use(response => {
-//   return response;
-// }, error => {
-//   // 例如，处理 401 未授权错误，跳转到登录页
-//   if (error.response.status === 401) {
-//     // router.push('/login');
-//   }
-//   return Promise.reject(error);
-// });
+// 统一处理错误，如未授权时清除 token
+apiClient.interceptors.response.use(
+  response => response,
+  error => {
+    if (error.response && error.response.status === 401) {
+      localStorage.removeItem('token');
+    }
+    return Promise.reject(error);
+  }
+);
 
 export default apiClient;

--- a/frontend-admin/src/store/modules/auth.js
+++ b/frontend-admin/src/store/modules/auth.js
@@ -1,0 +1,20 @@
+import { defineStore } from 'pinia';
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    token: localStorage.getItem('token') || null,
+  }),
+  actions: {
+    setToken(token) {
+      this.token = token;
+      if (token) {
+        localStorage.setItem('token', token);
+      } else {
+        localStorage.removeItem('token');
+      }
+    },
+    logout() {
+      this.setToken(null);
+    }
+  },
+});

--- a/frontend-admin/src/views/Login.vue
+++ b/frontend-admin/src/views/Login.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="login-container">
+    <el-card class="login-card">
+      <h2 class="title">后台登录</h2>
+      <el-form :model="form" @submit.prevent="handleSubmit">
+        <el-form-item label="邮箱">
+          <el-input v-model="form.email" autocomplete="email" />
+        </el-form-item>
+        <el-form-item label="密码">
+          <el-input v-model="form.password" type="password" autocomplete="current-password" />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" @click="handleSubmit" :loading="loading">登录</el-button>
+        </el-form-item>
+      </el-form>
+    </el-card>
+  </div>
+</template>
+
+<script setup>
+import { reactive, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { ElMessage } from 'element-plus';
+import apiClient from '../services/apiClient';
+import { useAuthStore } from '../store/modules/auth';
+
+const router = useRouter();
+const authStore = useAuthStore();
+const form = reactive({ email: '', password: '' });
+const loading = ref(false);
+
+const handleSubmit = async () => {
+  loading.value = true;
+  try {
+    const res = await apiClient.post('/auth/login', form);
+    if (res.data && res.data.token) {
+      authStore.setToken(res.data.token);
+      ElMessage.success('登录成功');
+      router.push('/layers');
+    }
+  } catch (err) {
+    ElMessage.error(err.response?.data?.message || '登录失败');
+  } finally {
+    loading.value = false;
+  }
+};
+</script>
+
+<style scoped>
+.login-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+.login-card {
+  width: 400px;
+}
+.title {
+  text-align: center;
+  margin-bottom: 20px;
+}
+</style>


### PR DESCRIPTION
## Summary
- build User model with email, hashed password and role
- implement registration & login controllers issuing JWTs
- create middleware to protect routes using JWT
- wire up auth routes and mount in server
- secure existing API routes
- add login view for admin and store token via Pinia
- send auth token on every request from the admin UI

## Testing
- `node -v`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6880e8aa6ff8832d9b80496b20b38847