### PR TITLE
Fix sidebar active route binding

### DIFF
--- a/frontend-admin/src/components/layout/Sidebar.vue
+++ b/frontend-admin/src/components/layout/Sidebar.vue
@@ -28,9 +28,10 @@
 
 <script setup>
 import { useRoute } from 'vue-router'
+import { computed } from 'vue'
 
 const route = useRoute()
-const activeRoute = route.path
+const activeRoute = computed(() => route.path)
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- bind sidebar active route reactively

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6881a69ed8f8832d823047e35fd3bf95