### PR TITLE
Fix public API base URL

### DIFF
--- a/frontend-public/.env
+++ b/frontend-public/.env
@@ -1,4 +1,4 @@
 # frontend-public/.env
 
 # 定义公开网站的后端 API 地址
-VITE_API_PUBLIC_BASE_URL=http://localhost:5001/api/public
+VITE_API_PUBLIC_BASE_URL=http://localhost:5000/api

--- a/frontend-public/src/App.vue
+++ b/frontend-public/src/App.vue
@@ -72,7 +72,7 @@ const fetchPublicData = async () => {
   loading.value = true;
   error.value = null;
   try {
-    const response = await apiClient.get('/data');
+    const response = await apiClient.get('/public/data');
     if (response.data && response.data.success) {
       data.value = response.data.data;
     } else {

--- a/frontend-public/src/services/apiClient.js
+++ b/frontend-public/src/services/apiClient.js
@@ -7,7 +7,8 @@ import axios from 'axios';
 // 创建 axios 实例
 const apiClient = axios.create({
   // 修正：使用 import.meta.env.VITE_API_PUBLIC_BASE_URL 来获取环境变量
-  baseURL: import.meta.env.VITE_API_PUBLIC_BASE_URL || 'http://localhost:5001/api/public',
+  // 默认指向后端 API 根路径，可通过环境变量覆盖
+  baseURL: import.meta.env.VITE_API_PUBLIC_BASE_URL || 'http://localhost:5000/api',
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
## Summary
- update frontend-public axios baseURL to match backend
- change public data route to keep `/public` path
- update example .env for public frontend

## Testing
- `npm run build` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6881a69e91ac832d81d535d2620756ff